### PR TITLE
System wide installation added

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+nmh_user_specific_path:="$$HOME/.mozilla/native-messaging-hosts"
+nmh_system_wide_path:="/usr/lib/mozilla/native-messaging-hosts"
+local_system_bin_path:="/usr/local/bin"
+
 build: install
 	@cd popup && npm install && npm run build
 	@web-ext build
@@ -6,16 +10,46 @@ dev: install
 	tmux new-session 'cd popup; git ls-files | entr npm run build' ';' \
 		 split-window 'web-ext run'
 
-install:
-	@mkdir -p ~/.mozilla/native-messaging-hosts
+install-user-home:
+	@mkdir -p $(nmh_user_specific_path)
 	@for f in helper/*; do \
-		sed "s#@HOME@#$$HOME#" $$PWD/$$f > ~/.mozilla/native-messaging-hosts/$$(basename $$f) ; \
-		chmod u+x ~/.mozilla/native-messaging-hosts/yt_dlp_firefox ; \
+		sed "s#@HOME@#$$HOME#" $$PWD/$$f > $(nmh_user_specific_path)/$$(basename $$f) ; \
+		chmod u+x $(nmh_user_specific_path)/yt_dlp_firefox ; \
 	done
 
-uninstall:
-	@cd helper; for f in *; do \
-		rm -f ~/.mozilla/native-messaging-hosts/$$f ; \
+install-system-wide:
+	@mkdir -p $(nmh_system_wide_path)
+	@sed "s#@HOME@/.mozilla/native-messaging-hosts#$(local_system_bin_path)#" helper/yt_dlp_firefox.json > $(nmh_system_wide_path)/yt_dlp_firefox.json
+	@cp helper/yt_dlp_firefox $(local_system_bin_path)/
+	@chmod +x $(local_system_bin_path)/yt_dlp_firefox
+
+install:
+ifneq ($(shell id -u), 0)
+	@echo "Performing installation to user specific home directory, if you like to install it system wide, you need to execute it with superuser rights"
+	$(MAKE) install-user-home
+else
+	@echo "Performing installation system wide, it will be available for all users"
+	$(MAKE) install-system-wide
+endif
+
+uninstall-user-home:
+	@cd helper; for f in *; do \\
+		rm -f $(nmh_user_specific_path)/$$f ; \
 	done
+
+uninstall-system-wide:
+	@cd helper; for f in *; do \
+		rm -f $(nmh_system_wide_path)/$$f ; \
+	done
+	@rm -f $(local_system_bin_path)/yt_dlp_firefox
+
+uninstall:
+ifneq ($(shell id -u), 0)
+	@echo "Performing uninstallation from user specific home directory, if you like to uninstall it system wide, you need to execute it with superuser rights"
+	$(MAKE) uninstall-user-home
+else
+	@echo "Performing uninstallation system wide"
+	$(MAKE) uninstall-system-wide
+endif
 
 .PHONY: build dev install uninstall

--- a/README.md
+++ b/README.md
@@ -6,7 +6,16 @@ A Firefox browser extension for downloading media with [`yt-dlp`](https://github
 
 Install the extension from [here](https://addons.mozilla.org/en-US/firefox/addon/yt-dlp-downloader/).
 
-Then clone this repository and run `make install` to install the required helper.
+Then clone this repository and run `make install` to install the required helper in user home directory.
+
+If you want to install it as system wide application, then you need to execute installation with superuser rights, for example:
+
+`sudo make install`
+
+## Uninstallation
+To remove from user home directory execute `make uninstall`
+
+If you installed it as system wide, you need to run `sudo make uninstall`
 
 ## Snap/flatpak permissions
 


### PR DESCRIPTION
If there is more users on particular system installation can be performed only once and all user can use it instantly

FireFox can load native messagers from /usr/lib/mozilla/native-messaging-hosts python script will be placed in /usr/local/bin/yt_dlp_firefox