### PR TITLE
Add installation support for various Firefox-derivative browsers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+INSTALL_DIR ?= $(HOME)/mozilla
+
 build: install
 	@cd popup && npm install && npm run build
 	@web-ext build
@@ -7,15 +9,15 @@ dev: install
 		 split-window 'web-ext run'
 
 install:
-	@mkdir -p ~/.mozilla/native-messaging-hosts
+	@mkdir -p $(INSTALL_DIR)/native-messaging-hosts
 	@for f in helper/*; do \
-		sed "s#@HOME@#$$HOME#" $$PWD/$$f > ~/.mozilla/native-messaging-hosts/$$(basename $$f) ; \
-		chmod u+x ~/.mozilla/native-messaging-hosts/yt_dlp_firefox ; \
+		sed "s#@HOME@#$$HOME#" $$PWD/$$f > $(INSTALL_DIR)/native-messaging-hosts/$$(basename $$f) ; \
+		chmod u+x $(INSTALL_DIR)/native-messaging-hosts/yt_dlp_firefox ; \
 	done
 
 uninstall:
 	@cd helper; for f in *; do \
-		rm -f ~/.mozilla/native-messaging-hosts/$$f ; \
+		rm -f $(INSTALL_DIR)/native-messaging-hosts/$$f ; \
 	done
 
 .PHONY: build dev install uninstall

--- a/README.md
+++ b/README.md
@@ -6,7 +6,17 @@ A Firefox browser extension for downloading media with [`yt-dlp`](https://github
 
 Install the extension from [here](https://addons.mozilla.org/en-US/firefox/addon/yt-dlp-downloader/).
 
-Then clone this repository and run `make install` to install the required helper.
+Then clone this repository and run `make install INSTALL_DIR=$INSTALL_DIR` to install the required helper based on your browser:
+
+| Browser                                                                                                                                        | $INSTALL_DIR           |
+|:-----------------------------------------------------------------------------------------------------------------------------------------------|:-----------------------|
+| [Firefox](https://support.mozilla.org/en-US/kb/install-firefox-linux#w_install-firefox-deb-package-for-debian-based-distributions-recommended) | $HOME/.mozilla         |
+| Firefox Developer Edition                                                                                                                      | $HOME/.mozilla         |
+| Firefox Nightly                                                                                                                                | $HOME/.mozilla         |
+| [LibreWolf](https://librewolf.net/installation/debian/)                                                                                        | $HOME/.librewolf       |
+| [Mullvad](https://mullvad.net/en/download/browser/linux)                                                                                       | $HOME/.mullvad-browser |
+
+Note that this is assuming that you have downloaded your browser through a Debian repository or other package manager.
 
 ## Snap/flatpak permissions
 


### PR DESCRIPTION
This branch simply modifies the Makefile such that it will install the helper for any browser whose native messaging hosts are located at '~/.[browser name]/native-messaging-hosts'. Some such supported browsers include LibreWolf and Mullvad.

The Tor Browser (as installed with the apt package "torbrowser-launcher") would not be among the supported browsers, as its file path for native messaging hosts does not follow this scheme (disregarding the sandboxing that renders the extension dysfunctional in the Tor Browser anyhow).