### PR TITLE
Add installation support for the Tor Browser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-INSTALL_DIR ?= $(HOME)/mozilla
+INSTALL_DIR ?= $(HOME)/.mozilla
+TOR_INSTALL_DIR ?= $(HOME)/.local/share/torbrowser/tbb/x86_64/tor-browser/Browser/TorBrowser/Data/Browser/.mozilla
 
 build: install
 	@cd popup && npm install && npm run build
@@ -8,16 +9,45 @@ dev: install
 	tmux new-session 'cd popup; git ls-files | entr npm run build' ';' \
 		 split-window 'web-ext run'
 
+define move_helper
+	$(eval $@_NMH_PARENT_DIR = $(1))
+	mkdir -p $($@_NMH_PARENT_DIR)/native-messaging-hosts
+    	for f in helper/*; do \
+    		sed "s#@NMH_PARENT_DIR@#$($@_NMH_PARENT_DIR)#" $$PWD/$$f > $($@_NMH_PARENT_DIR)/native-messaging-hosts/$$(basename $$f) ; \
+    		chmod u+x $($@_NMH_PARENT_DIR)/native-messaging-hosts/yt_dlp_firefox ; \
+    	done
+endef
+
 install:
-	@mkdir -p $(INSTALL_DIR)/native-messaging-hosts
-	@for f in helper/*; do \
-		sed "s#@HOME@#$$HOME#" $$PWD/$$f > $(INSTALL_DIR)/native-messaging-hosts/$$(basename $$f) ; \
-		chmod u+x $(INSTALL_DIR)/native-messaging-hosts/yt_dlp_firefox ; \
-	done
+	@$(call move_helper,$(INSTALL_DIR))
+
+install-tor:
+	@$(call move_helper, $(TOR_INSTALL_DIR))
+	@if ! grep -q "\"--proxy\", \"socks5h://127.0.0.1:9150\"," $(TOR_INSTALL_DIR)/native-messaging-hosts/yt_dlp_firefox; then \
+		sed -i "s#\(\"yt-dlp\",\)#\1 \"--proxy\", \"socks5h://127.0.0.1:9150\",#" $(TOR_INSTALL_DIR)/native-messaging-hosts/yt_dlp_firefox ; \
+		chmod u+x $(TOR_INSTALL_DIR)/native-messaging-hosts/yt_dlp_firefox ; \
+	fi
+	$(eval $@_APPARMOR_TOR_PATH = /etc/apparmor.d/torbrowser.Browser.firefox)
+	@if [ -f $($@_APPARMOR_TOR_PATH) ] && which apparmor_parser >/dev/null; then \
+		$(eval $@_APPARMOR_BYPASSES = \
+			"$(TOR_INSTALL_DIR)/native-messaging-hosts/yt_dlp_firefox rix" \
+			"$(shell readlink -f $$(which python3)) rix" \
+			"$(shell which yt-dlp) rix" \
+			"/usr/share/dpkg/\*\* r" \
+			"/usr/local/lib/ r" \
+			"/etc/apt/apt.conf.d/\*\* r" \
+			"/etc/ssl/certs/ca-certificates.crt r") \
+		for b in $($@_APPARMOR_BYPASSES); do \
+			if ! grep -q "^  $$b,$$" $($@_APPARMOR_TOR_PATH) ; then \
+				sudo sed -i "s|\(  #include <local/torbrowser.Browser.firefox>\)|  $$b,\n\1|" $($@_APPARMOR_TOR_PATH) ;  \
+			fi; \
+		done; \
+		sudo apparmor_parser -r $($@_APPARMOR_TOR_PATH) ; \
+	fi
 
 uninstall:
 	@cd helper; for f in *; do \
 		rm -f $(INSTALL_DIR)/native-messaging-hosts/$$f ; \
 	done
 
-.PHONY: build dev install uninstall
+.PHONY: build dev install install-tor uninstall

--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ Then clone this repository and run `make install INSTALL_DIR=$INSTALL_DIR` to in
 
 Note that this is assuming that you have downloaded your browser through a Debian repository or other package manager.
 
+### Tor Browser Installation
+
+```
+make install-tor
+```
+
+This is assuming that you have installed the Tor Browser via the Debian package `torbrowser-launcher`.
+If your path to the Tor Browser is elsewhere, you can run the above target like so:
+
+```
+make install-tor TOR_INSTALL_DIR=$TOR_INSTALL_DIR
+```
+
 ## Snap/flatpak permissions
 
 In case of web browser installed via snap/flatpak there might be a problem with accessing resources outside of sandbox. If you won't be asked for permissions you can add them using command line via following command:

--- a/helper/yt_dlp_firefox.json
+++ b/helper/yt_dlp_firefox.json
@@ -1,7 +1,7 @@
 {
   "name": "yt_dlp_firefox",
   "description": "Native host helper",
-  "path": "@HOME@/.mozilla/native-messaging-hosts/yt_dlp_firefox",
+  "path": "@NMH_PARENT_DIR@/native-messaging-hosts/yt_dlp_firefox",
   "type": "stdio",
   "allowed_extensions": ["yt_dlp_firefox@tyilo.com"]
 }


### PR DESCRIPTION
This branch adds a target to the `Makefile` that acts as installation support for the Tor Browser. It does so by:

1. Ensuring that requests made by yt-dlp are routed through the Tor network via the `--proxy` flag.
2. Giving permissions to yt-dlp, Python, and various resources accessed by Python by modifying the Tor Browser's AppArmor security profile (i.e., `/etc/apparmor.d/torbrowser.Browser.firefox`).
3. Reloading said security profile for the changes to take into effect.

Admittedly, this fix was done haphazardly on my part—I only took into consideration permissions that were found to be violated on my machine, so the code may very well not be cross-platform. Do take the time to consider the ramifications (even security-wise) of these changes, as valuable as adding Tor Browser support might be.

Thank you for your time.