### PR TITLE
Fix browser action behavior after restart

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "yt-dlp downloader",
   "description": "Download media using yt-dlp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "icons": {
     "48": "icon.svg"
   },


### PR DESCRIPTION
I checked the browser action behavior upon seeing #23 and found that it was indeed defaulting to "Open popup" every time Firefox was closed/re-opened. This patch seems to account for Manifest V2 re-running the background script every session.

I'm not exactly sure what caused this to be so, if it was not acting that way in the first place.